### PR TITLE
Feature/implement --list command to show managed domains

### DIFF
--- a/bin/winhost
+++ b/bin/winhost
@@ -17,15 +17,17 @@ case "$action" in
   domain="$1"
   shift
 
-  comment=$(get_comment "$@")
   ip=$(get_ip "$@")
+  comment=$(get_comment "$@")
 
   addhost --domain "$domain" --ip "$ip" --comment "$comment"
   ;;
-
 --remove | -r)
   domain="$1"
   removehost --domain "$domain"
+  ;;
+--list | -l)
+  listhosts
   ;;
 --help)
   msg help LONG

--- a/lib/functions
+++ b/lib/functions
@@ -269,3 +269,26 @@ get_ip() {
   done
   echo "$DEFAULT_IP_ADDRESS"
 }
+
+listhosts() {
+  local section="$1" line
+  local in_section=false
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" == "# $SECTION_START" ]]; then
+      in_section=true
+      continue
+    fi
+
+    if [[ "$in_section" == true ]]; then
+      if [[ "$line" == "# $SECTION_END" ]]; then
+        in_section=false
+        continue
+      fi
+
+      if [[ "$line" != \#* && -n "$line" ]]; then
+        echo "$line"
+      fi
+    fi
+  done <"$HOSTS_FILE"
+}

--- a/lib/functions
+++ b/lib/functions
@@ -248,7 +248,6 @@ get_comment() {
   for arg in "$1" "$2"; do
     [[ -z "$arg" ]] && continue
 
-    # Se o argumento contém qualquer caractere diferente de número ou ponto, é um comentário
     if ! echo "$arg" | grep -qE '^([0-9]+\.){0,3}[0-9]+$'; then
       echo "$arg"
       return
@@ -261,7 +260,6 @@ get_ip() {
   for arg in "$@"; do
     [[ -z "$arg" ]] && continue
 
-    # Remove números e pontos. Se o restante for vazio, é um IP-like
     if [[ -z "$(echo "$arg" | tr -d '0-9.')" ]]; then
       echo "$arg"
       return
@@ -273,14 +271,13 @@ get_ip() {
 listhosts() {
   local line ip domain comment
   local in_section=false
-  local format="| %-25s | %-15s | %-40s |\n"
+  local format="| %-23s | %-15s | %-27s |\n"
 
-  # Cabeçalho
   printf "\n"
-  printf " ----------------------------------------------------------------------------------------\n"
+  printf "+-------------------------------------------------------------------------+\n"
 
   printf "$format" "DOMAIN" "IP" "NOTES"
-  printf "|---------------------------+-----------------+------------------------------------------|\n"
+  printf "+-------------------------+-----------------+-----------------------------+\n"
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     if [[ "$line" == "# $SECTION_START" ]]; then
@@ -295,7 +292,6 @@ listhosts() {
       fi
 
       if [[ "$line" != \#* && -n "$line" ]]; then
-        # Extrair IP e domínio (primeiros dois campos)
         ip=$(echo "$line" | awk '{print $1}')
         domain=$(echo "$line" | awk '{print $2}')
         comment=$(echo "$line" | sed -n 's/.*#\s*\(.*\)/\1/p')
@@ -305,7 +301,8 @@ listhosts() {
     fi
   done < "$HOSTS_FILE"
 
-  printf " ----------------------------------------------------------------------------------------\n"
+  printf "+-------------------------------------------------------------------------+\n"
   printf "\n"
+  printf
 }
 

--- a/lib/functions
+++ b/lib/functions
@@ -271,8 +271,16 @@ get_ip() {
 }
 
 listhosts() {
-  local section="$1" line
+  local line ip domain comment
   local in_section=false
+  local format="| %-25s | %-15s | %-40s |\n"
+
+  # Cabeçalho
+  printf "\n"
+  printf " ----------------------------------------------------------------------------------------\n"
+
+  printf "$format" "DOMAIN" "IP" "NOTES"
+  printf "|---------------------------+-----------------+------------------------------------------|\n"
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     if [[ "$line" == "# $SECTION_START" ]]; then
@@ -287,8 +295,17 @@ listhosts() {
       fi
 
       if [[ "$line" != \#* && -n "$line" ]]; then
-        echo "$line"
+        # Extrair IP e domínio (primeiros dois campos)
+        ip=$(echo "$line" | awk '{print $1}')
+        domain=$(echo "$line" | awk '{print $2}')
+        comment=$(echo "$line" | sed -n 's/.*#\s*\(.*\)/\1/p')
+
+        printf "$format" "$domain" "$ip" "$comment"
       fi
     fi
-  done <"$HOSTS_FILE"
+  done < "$HOSTS_FILE"
+
+  printf " ----------------------------------------------------------------------------------------\n"
+  printf "\n"
 }
+


### PR DESCRIPTION
This PR implements the --list command to display all domains managed by WinHostCLI inside the configured section of the Windows hosts file.

## What’s changed

- Added new function listhosts() to parse the hosts file and extract:
  - IP
  - Domain
  - Optional inline comment
- The output is now formatted in a clean CLI-style table.
- Introduced formatting using ANSI escape codes for better readability.
- Ensures output excludes unrelated entries and focuses only on domains managed by WinHostCLI.

## Usage
```bash
winhost --list
```

### Example output:

```bash
+-------------------------------------------------------------------------+
| DOMAIN                  | IP              | NOTES                       |
+-------------------------+-----------------+-----------------------------+
| myproject1.domain       | 127.0.0.1       | Custom notes                |
| myproject2.domain       | 192.168.0.1     |                             |
+-------------------------------------------------------------------------+
```

## Benefits

- Allows developers to visualize all mapped domains in one command.
- Useful for debugging and reviewing current dev environments.
- Keeps consistency with other CLI tools that show formatted listings.